### PR TITLE
Added prop for mime type, to allow for different image types to be generated

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ import VideoThumbnail from 'react-video-thumbnail'; // use npm published version
 | **snapshotAtTime** | **int** | 2 | The second at which the component should snap the image at. |
 | **thumbnailHandler** | **func** | | Callback function that takes in **thumbnail** url as an argument |
 | **width** | **int** | | Resize thumbnail to specified width |
+| **mimeType** | **string** | image/png |Type of image that will be generated | 
 
 *Note: The longer the snapshotAtTime, the more video data it may have to download.
 

--- a/src/components/VideoThumbnail.js
+++ b/src/components/VideoThumbnail.js
@@ -36,6 +36,7 @@ export default class VideoThumbnail extends React.Component {
             snapshotAtTime: props.snapshotAtTime,       // number
             thumbnailHandler: props.thumbnailHandler,   // callback function
             videoUrl: props.videoUrl,                   // string
+            mimeType: props.mimeType,                   // string
         }
     }
 
@@ -117,7 +118,7 @@ export default class VideoThumbnail extends React.Component {
      */
     getSnapShot = () => {
         try {
-            const { width, height } = this.props;
+            const { width, height, mimeType } = this.props;
             const video = this.refs.videoEl;
             const canvas = this.refs.canvas;
             canvas.height = video.videoHeight;
@@ -130,7 +131,7 @@ export default class VideoThumbnail extends React.Component {
                 canvas.getContext('2d').drawImage(video, 0, 0, width, height);
             }
 
-            const thumbnail = canvas.toDataURL('image/png');
+            const thumbnail = canvas.toDataURL(mimeType);
 
             // Remove video & canvas elements (no longer needed)
             video.src = "";  // setting to empty string stops video from loading
@@ -163,6 +164,7 @@ VideoThumbnail.propTypes = {
     snapshotAtTime: PropTypes.number,
     thumbnailHandler: PropTypes.func,
     videoUrl: PropTypes.string.isRequired,
+    mimeType: PropTypes.string,
 }
 
 /**
@@ -172,4 +174,5 @@ VideoThumbnail.defaultProps = {
     cors: false,
     renderThumbnail: true,
     snapshotAtTime: 2,
+    mimeType: "image/png",
 }


### PR DESCRIPTION
Really cool tool, been using it recently and its working well but one issue I've had is the hardcoded mime type of "image/png". Being able to swap out that to a user supplied type would be great. For example, switching it out to "image/jpeg" for 1080p videos brings down the generated image size to one tenth of the original png size. 